### PR TITLE
Release 4.0

### DIFF
--- a/BMTLab.StateResults.sln
+++ b/BMTLab.StateResults.sln
@@ -17,7 +17,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "config", "config", "{2902D3
 		.config\dotnet-tools.json = .config\dotnet-tools.json
 		.editorconfig = .editorconfig
 		.config\watchers.xml = .config\watchers.xml
-		.github\workflows\publish.yml = .github\workflows\publish.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{820D1787-2357-4A04-9D2B-C8A243358D07}"
@@ -61,6 +60,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{38D5
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StateResults.Generator", "src\StateResults.Generator\StateResults.Generator.csproj", "{D015C734-B408-4291-8B27-FAB51DDE736B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{846879B0-9A66-40F6-89AA-80289864788F}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\publish.yml = .github\workflows\publish.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -98,5 +102,6 @@ Global
 		{38D58662-03FD-408A-A7E2-6AABEB689E3C} = {820D1787-2357-4A04-9D2B-C8A243358D07}
 		{34128E1F-D9C0-469F-B418-960C0A122A69} = {38D58662-03FD-408A-A7E2-6AABEB689E3C}
 		{D015C734-B408-4291-8B27-FAB51DDE736B} = {820D1787-2357-4A04-9D2B-C8A243358D07}
+		{846879B0-9A66-40F6-89AA-80289864788F} = {2902D3CB-5B33-4189-9AF9-D905D78FF11D}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <PropertyGroup Label="Version">
-        <Major>3</Major>
-        <Minor>3</Minor>
+        <Major>4</Major>
+        <Minor>0</Minor>
         <Build>$(CurrentDate)</Build>
         <Revision>$(CurrentTime)</Revision>
         <PreReleaseLabel>preview</PreReleaseLabel>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,9 +13,9 @@
   <ItemGroup Label="Analyzers">
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.20.0.85982" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.23.0.88079" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -29,7 +29,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="coverlet.collector" Version="6.0.1">
+    <PackageVersion Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BMTLab.StateResults 
-[![NuGet](https://img.shields.io/nuget/v/OneOf?logo=nuget)](https://www.nuget.org/packages/BMTLab.StateResults)
+[![NuGet](https://img.shields.io/nuget/v/BMTLab.StateResults?logo=nuget)](https://www.nuget.org/packages/BMTLab.StateResults)
 ![Nuget Downloads](https://img.shields.io/nuget/dt/BMTLab.StateResults)
 ![.NET](https://github.com/BMTLab/StateResults/workflows/publish/badge.svg)
 

--- a/scripts/clean.ps1
+++ b/scripts/clean.ps1
@@ -1,39 +1,61 @@
 <#
 .SYNOPSIS
-This script cleans specified directories and files in a project.
+This script is designed to clean specified directories and files in a project.
+It provides a flexible way to remove build artifacts, temporary files, and other not needed directories and files.
+
+.DESCRIPTION
+This script offers a way to systematically remove unwanted files and directories from a project, improving cleanliness and maintainability.
+
+.AUTHOR
+Nikita Neverov (BMTLab)
+
+.VERSION
+1.0.1
 #>
 
-# Print start message
-Write-Host "Cleaning projects.."
-
-# Function to clean specified directories
+# Function to clean directories matching a specific pattern.
 function Clean-Directories
 {
     param (
         [Parameter(Mandatory = $true)]
         [string]$Pattern
     )
+
+    Write-Host "Cleaning directories matching pattern: $Pattern"
     Get-ChildItem -Path .. -Recurse -Directory -Filter $Pattern | Remove-Item -Recurse -Force
 }
 
-# Function to clean specified files
+# Function to clean files matching a specific pattern.
 function Clean-Files
 {
     param (
         [Parameter(Mandatory = $true)]
         [string]$Pattern
     )
+
+    Write-Host "Cleaning files matching pattern: $Pattern"
     Get-ChildItem -Path .. -Recurse -File -Filter $Pattern | Remove-Item -Force
 }
 
-# Clean directories: build, bin, obj, and out
-Clean-Directories -Pattern "build*"
-Clean-Directories -Pattern "bin"
-Clean-Directories -Pattern "obj"
-Clean-Directories -Pattern "out"
+# Main function to orchestrate cleaning operations.
+function Main
+{
+    Write-Host "Starting cleaning process..."
 
-# Clean VERSION.g.txt files
-Clean-Files -Pattern "VERSION.g.txt"
+    # List of patterns for directories to clean
+    $dirPatterns = @('build*', 'bin', 'obj', 'out')
 
-# Print completion message
-Write-Host "Success. Cleaning completed"
+    # Clean directories
+    foreach ($pattern in $dirPatterns)
+    {
+        Clean-Directories -Pattern $pattern
+    }
+
+    # Clean files
+    Clean-Files -Pattern "VERSION.g.txt"
+
+    Write-Host "Cleaning completed!"
+}
+
+# Execute the main function
+Main

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,27 +1,62 @@
 #!/bin/bash
-# This script cleans specified directories and files in a project.
+
+# Author: Nikita Neverov (BMTLab)
+# Version: 1.0.1
 
 # Do not forget
-# chmod +x transform_location.sh
+# sudo chmod +x ./clean.sh
 
-echo 'Cleaning projects..'
+# Description: This script is designed to clean specified directories and files in a project.
+# It provides a flexible way to remove build artifacts, temporary files, and other not needed directories and files.
 
-# Function to clean specified directories.
-clean_directories() {
-  local pattern="$1"
+#######################################
+# Clean directories matching a specific pattern.
+# Arguments:
+#   pattern: The pattern to match directories to be cleaned.
+# Outputs:
+#   Writes names of cleaned directories to stdout.
+#######################################
+function clean_directories() {
+  local -r pattern="$1"
+  printf 'Cleaning directories matching pattern: %s.\n' "$pattern"
   find .. -name "$pattern" -type d -print0 | xargs -r0 rm -r
 }
 
-# Function to clean specified files.
-clean_files() {
-  local pattern="$1"
+#######################################
+# Clean files matching a specific pattern.
+# Arguments:
+#   pattern: The pattern to match files to be cleaned.
+# Outputs:
+#   Writes names of cleaned files to stdout.
+#######################################
+function clean_files() {
+  local -r pattern="$1"
+  printf 'Cleaning files matching pattern: %s.\n' "$pattern"
   find .. -name "$pattern" -type f -print0 | xargs -r0 rm
 }
 
-clean_directories 'build*'
-clean_directories 'bin'
-clean_directories 'obj'
-clean_directories 'out'
-clean_files 'VERSION.g.txt'
+#######################################
+# The main function to orchestrate cleaning operations.
+# It calls other functions with specific patterns to clean up project artifacts.
+# Outputs:
+#   Writes progress and results of cleaning operations to stdout.
+#######################################
+function main() {
+  printf 'Starting cleaning process...'
 
-echo 'Success. Cleaning completed'
+  # List of patterns for directories to clean
+  local -ar dir_patterns_arr=('build*' 'bin' 'obj' 'out')
+
+  # Clean directories
+  for pattern in "${dir_patterns_arr[@]}"; do
+    clean_directories "$pattern"
+  done
+
+  # Clean files
+  clean_files 'VERSION.g.txt'
+
+  printf 'Cleaning completed!'
+}
+
+# Execute the main function with all passed arguments
+main "$@"

--- a/scripts/rewrite-pkg-version.sh
+++ b/scripts/rewrite-pkg-version.sh
@@ -52,11 +52,11 @@ EOF
 #######################################
 function __error() {
   local -r message="$1"
-  local -r code="${2:-1}" # Default error code is 1
+  local -ir code=${2:-1} # Default error code is 1
 
   printf 'Error: %s.\n' "$message" >&2
   usage
-  exit "$code"
+  exit $code
 }
 
 #######################################

--- a/src/OneOf.Reduced/OneOf.g.cs
+++ b/src/OneOf.Reduced/OneOf.g.cs
@@ -29,7 +29,7 @@ public class OneOf<T0, T1> : IOneOf, IEquatable<OneOf<T0, T1>>
         in T1? value1 = default
     )
     {
-        Debug.Assert(index < 0, CorruptedMessage);
+        Debug.Assert(index >= 0, CorruptedMessage);
 
         Index = index;
         _value0 = value0;
@@ -292,7 +292,7 @@ public class OneOf<T0, T1, T2> : IOneOf, IEquatable<OneOf<T0, T1, T2>>
         in T2? value2 = default
     )
     {
-        Debug.Assert(index < 0, CorruptedMessage);
+        Debug.Assert(index >= 0, CorruptedMessage);
 
         Index = index;
         _value0 = value0;
@@ -604,7 +604,7 @@ public class OneOf<T0, T1, T2, T3> : IOneOf, IEquatable<OneOf<T0, T1, T2, T3>>
         in T3? value3 = default
     )
     {
-        Debug.Assert(index < 0, CorruptedMessage);
+        Debug.Assert(index >= 0, CorruptedMessage);
 
         Index = index;
         _value0 = value0;
@@ -965,7 +965,7 @@ public class OneOf<T0, T1, T2, T3, T4> : IOneOf, IEquatable<OneOf<T0, T1, T2, T3
         in T4? value4 = default
     )
     {
-        Debug.Assert(index < 0, CorruptedMessage);
+        Debug.Assert(index >= 0, CorruptedMessage);
 
         Index = index;
         _value0 = value0;
@@ -1375,7 +1375,7 @@ public class OneOf<T0, T1, T2, T3, T4, T5> : IOneOf, IEquatable<OneOf<T0, T1, T2
         in T5? value5 = default
     )
     {
-        Debug.Assert(index < 0, CorruptedMessage);
+        Debug.Assert(index >= 0, CorruptedMessage);
 
         Index = index;
         _value0 = value0;

--- a/src/OneOf.Reduced/OneOf.g.tt
+++ b/src/OneOf.Reduced/OneOf.g.tt
@@ -68,7 +68,7 @@ public class OneOf<<#= typesText #>> : IOneOf, IEquatable<OneOf<<#= typesText #>
 #>
     )
     {
-        Debug.Assert(index < 0, CorruptedMessage);
+        Debug.Assert(index >= 0, CorruptedMessage);
 
         Index = index;
 <#

--- a/src/OneOf.Reduced/Utils/Functions.cs
+++ b/src/OneOf.Reduced/Utils/Functions.cs
@@ -2,6 +2,7 @@
 
 [DebuggerStepThrough]
 [StackTraceHidden]
+[ExcludeFromCodeCoverage]
 internal static class Functions
 {
     [Pure]

--- a/src/StateResults/Result.cs
+++ b/src/StateResults/Result.cs
@@ -72,6 +72,8 @@ public readonly record struct Result<T> : IOneOf, IHasSuccessOrErrorResult
 
 
     public static bool operator true(in Result<T> result) => result.IsSuccess;
+
+    [ExcludeFromCodeCoverage]
     public static bool operator false(in Result<T> result) => result.IsError;
     #endregion _Operators
 

--- a/src/StateResults/Results.cs
+++ b/src/StateResults/Results.cs
@@ -91,6 +91,8 @@ public readonly record struct Results<TSuccess, TError> : IOneOf, IHasSuccessOrE
 
 
     public static bool operator true(in Results<TSuccess, TError> result) => result.IsSuccess;
+
+    [ExcludeFromCodeCoverage]
     public static bool operator false(in Results<TSuccess, TError> result) => result.IsError;
     #endregion _Operators
 

--- a/src/StateResults/Results.g.cs
+++ b/src/StateResults/Results.g.cs
@@ -70,12 +70,17 @@ public readonly record struct Results<TSuccess, TE0, TE1> : IOneOf, IHasSuccessO
     public object Value => _index switch
     {
         0 when Success is not null => Success,
-        1 when Error is not null   => Error,
+        1 when Error is not null   => Error.Value,
         var _                      => throw new InvalidOperationException(CorruptedMessage)
     };
 
     /// <inheritdoc />
-    public int Index => _index;
+    public int Index => _index switch
+    {
+        0 when Success is not null => 0,
+        1 when Error is not null   => Error.Index + 1,
+        var _                      => throw new InvalidOperationException(CorruptedMessage)
+    };
 
     /// <inheritdoc />
     public bool IsError => !IsSuccess;
@@ -116,6 +121,8 @@ public readonly record struct Results<TSuccess, TE0, TE1> : IOneOf, IHasSuccessO
 
 
     public static bool operator true(in Results<TSuccess, TE0, TE1> result) => result.IsSuccess;
+
+    [ExcludeFromCodeCoverage]
     public static bool operator false(in Results<TSuccess, TE0, TE1> result) => result.IsError;
     #endregion _Operators
 
@@ -356,12 +363,17 @@ public readonly record struct Results<TSuccess, TE0, TE1, TE2> : IOneOf, IHasSuc
     public object Value => _index switch
     {
         0 when Success is not null => Success,
-        1 when Error is not null   => Error,
+        1 when Error is not null   => Error.Value,
         var _                      => throw new InvalidOperationException(CorruptedMessage)
     };
 
     /// <inheritdoc />
-    public int Index => _index;
+    public int Index => _index switch
+    {
+        0 when Success is not null => 0,
+        1 when Error is not null   => Error.Index + 1,
+        var _                      => throw new InvalidOperationException(CorruptedMessage)
+    };
 
     /// <inheritdoc />
     public bool IsError => !IsSuccess;
@@ -410,6 +422,8 @@ public readonly record struct Results<TSuccess, TE0, TE1, TE2> : IOneOf, IHasSuc
 
 
     public static bool operator true(in Results<TSuccess, TE0, TE1, TE2> result) => result.IsSuccess;
+
+    [ExcludeFromCodeCoverage]
     public static bool operator false(in Results<TSuccess, TE0, TE1, TE2> result) => result.IsError;
     #endregion _Operators
 
@@ -656,12 +670,17 @@ public readonly record struct Results<TSuccess, TE0, TE1, TE2, TE3> : IOneOf, IH
     public object Value => _index switch
     {
         0 when Success is not null => Success,
-        1 when Error is not null   => Error,
+        1 when Error is not null   => Error.Value,
         var _                      => throw new InvalidOperationException(CorruptedMessage)
     };
 
     /// <inheritdoc />
-    public int Index => _index;
+    public int Index => _index switch
+    {
+        0 when Success is not null => 0,
+        1 when Error is not null   => Error.Index + 1,
+        var _                      => throw new InvalidOperationException(CorruptedMessage)
+    };
 
     /// <inheritdoc />
     public bool IsError => !IsSuccess;
@@ -718,6 +737,8 @@ public readonly record struct Results<TSuccess, TE0, TE1, TE2, TE3> : IOneOf, IH
 
 
     public static bool operator true(in Results<TSuccess, TE0, TE1, TE2, TE3> result) => result.IsSuccess;
+
+    [ExcludeFromCodeCoverage]
     public static bool operator false(in Results<TSuccess, TE0, TE1, TE2, TE3> result) => result.IsError;
     #endregion _Operators
 
@@ -970,12 +991,17 @@ public readonly record struct Results<TSuccess, TE0, TE1, TE2, TE3, TE4> : IOneO
     public object Value => _index switch
     {
         0 when Success is not null => Success,
-        1 when Error is not null   => Error,
+        1 when Error is not null   => Error.Value,
         var _                      => throw new InvalidOperationException(CorruptedMessage)
     };
 
     /// <inheritdoc />
-    public int Index => _index;
+    public int Index => _index switch
+    {
+        0 when Success is not null => 0,
+        1 when Error is not null   => Error.Index + 1,
+        var _                      => throw new InvalidOperationException(CorruptedMessage)
+    };
 
     /// <inheritdoc />
     public bool IsError => !IsSuccess;
@@ -1040,6 +1066,8 @@ public readonly record struct Results<TSuccess, TE0, TE1, TE2, TE3, TE4> : IOneO
 
 
     public static bool operator true(in Results<TSuccess, TE0, TE1, TE2, TE3, TE4> result) => result.IsSuccess;
+
+    [ExcludeFromCodeCoverage]
     public static bool operator false(in Results<TSuccess, TE0, TE1, TE2, TE3, TE4> result) => result.IsError;
     #endregion _Operators
 
@@ -1298,12 +1326,17 @@ public readonly record struct Results<TSuccess, TE0, TE1, TE2, TE3, TE4, TE5> : 
     public object Value => _index switch
     {
         0 when Success is not null => Success,
-        1 when Error is not null   => Error,
+        1 when Error is not null   => Error.Value,
         var _                      => throw new InvalidOperationException(CorruptedMessage)
     };
 
     /// <inheritdoc />
-    public int Index => _index;
+    public int Index => _index switch
+    {
+        0 when Success is not null => 0,
+        1 when Error is not null   => Error.Index + 1,
+        var _                      => throw new InvalidOperationException(CorruptedMessage)
+    };
 
     /// <inheritdoc />
     public bool IsError => !IsSuccess;
@@ -1376,6 +1409,8 @@ public readonly record struct Results<TSuccess, TE0, TE1, TE2, TE3, TE4, TE5> : 
 
 
     public static bool operator true(in Results<TSuccess, TE0, TE1, TE2, TE3, TE4, TE5> result) => result.IsSuccess;
+
+    [ExcludeFromCodeCoverage]
     public static bool operator false(in Results<TSuccess, TE0, TE1, TE2, TE3, TE4, TE5> result) => result.IsError;
     #endregion _Operators
 

--- a/src/StateResults/Results.g.tt
+++ b/src/StateResults/Results.g.tt
@@ -97,12 +97,17 @@ public readonly record struct Results<TSuccess, <#= errorTypesText #>> : IOneOf,
     public object Value => _index switch
     {
         0 when Success is not null => Success,
-        1 when Error is not null   => Error,
+        1 when Error is not null   => Error.Value,
         var _                      => throw new InvalidOperationException(CorruptedMessage)
     };
 
     /// <inheritdoc />
-    public int Index => _index;
+    public int Index => _index switch
+    {
+        0 when Success is not null => 0,
+        1 when Error is not null   => Error.Index + 1,
+        var _                      => throw new InvalidOperationException(CorruptedMessage)
+    };
 
     /// <inheritdoc />
     public bool IsError => !IsSuccess;
@@ -149,6 +154,8 @@ public readonly record struct Results<TSuccess, <#= errorTypesText #>> : IOneOf,
 #>
 
     public static bool operator true(in Results<TSuccess, <#= errorTypesText #>> result) => result.IsSuccess;
+
+    [ExcludeFromCodeCoverage]
     public static bool operator false(in Results<TSuccess, <#= errorTypesText #>> result) => result.IsError;
     #endregion _Operators
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,6 +12,7 @@
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
 
         <NoWarn>$(NoWarn);CA1707</NoWarn><!--Remove underscore in method name-->
+        <NoWarn>$(NoWarn);CA2007</NoWarn><!--Consider calling ConfigureAwait on the awaited task-->
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/UnitTests/StateResults.Tests.Unit/Helpers/OneTypeClassData.cs
+++ b/tests/UnitTests/StateResults.Tests.Unit/Helpers/OneTypeClassData.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+
+namespace BMTLab.StateResults.Tests.Units;
+
+internal sealed class OneTypeClassData : IEnumerable<object[]>
+{
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        yield return ["some value"];
+        yield return [0];
+        yield return [true];
+        yield return [new object()];
+        yield return [new ArgumentException("some exception")];
+        yield return [new SomeStructType()];
+        yield return [new SomeClassError()];
+        yield return [new SomeRecordType()];
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+
+internal sealed class TwoTypesClassData : IEnumerable<object[]>
+{
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        yield return [new SomeStructType("Test"), new SomeStructType2("Test")];
+        yield return [new SomeClassError(), new SomeClassError2()];
+        yield return [new SomeRecordType("Test"), new SomeRecordType2("Test")];
+        yield return [new SomeRecordType(), new SomeStructType()];
+        yield return [new SomeClassError(), new SomeRecordType()];
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/tests/UnitTests/StateResults.Tests.Unit/Helpers/TestStates.cs
+++ b/tests/UnitTests/StateResults.Tests.Unit/Helpers/TestStates.cs
@@ -1,0 +1,11 @@
+namespace BMTLab.StateResults.Tests.Units.Helpers;
+
+internal static class TestStates
+{
+    internal readonly record struct SomeStructType(string? Message = default);
+    internal readonly record struct SomeStructType2(string? Message = default);
+    internal class SomeClassError(string? Message = default);
+    internal class SomeClassError2(string? Message = default);
+    internal record SomeRecordType(string? Message = default);
+    internal record SomeRecordType2(string? Message = default);
+}

--- a/tests/UnitTests/StateResults.Tests.Unit/Properties/GlobalUsings.cs
+++ b/tests/UnitTests/StateResults.Tests.Unit/Properties/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using static BMTLab.StateResults.Tests.Units.Helpers.TestStates;

--- a/tests/UnitTests/StateResults.Tests.Unit/ResultTests.cs
+++ b/tests/UnitTests/StateResults.Tests.Unit/ResultTests.cs
@@ -2,155 +2,179 @@ using BMTLab.OneOf.Reduced;
 
 namespace BMTLab.StateResults.Tests.Units;
 
-public class ResultTests
+public sealed class ResultTests
 {
-    [Fact]
-    public void Result_Should_InitializeWithSuccessValue()
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void Result_Should_InitializeWithSuccessValue<T>(T value) where T : notnull
     {
         //// Arrange & Act
-        var result = new Result<string>("success");
+        var result = new Result<T>(value);
 
         //// Assert
-        result.IsSuccess.Should().BeTrue();
-        result.IsError.Should().BeFalse();
-        result.Value.Should().Be("success");
+        result.IsSuccess.Should().BeTrue("a result initialized with a value should be successful");
+        result.IsError.Should().BeFalse("a result initialized with a value should not be an error");
+        result.Value.Should().Be(value, "the value passed during initialization should be accessible");
     }
 
 
-    [Fact]
-    public void Result_Should_InitializeWithErrorValue()
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void Result_Should_InitializeWithErrorValue<T>(T value) where T : notnull
     {
         //// Arrange & Act
-        var result = new Result<string>("error", false);
+        var result = new Result<T>(value, false);
 
         //// Assert
-        result.IsSuccess.Should().BeFalse();
-        result.IsError.Should().BeTrue();
-        result.Value.Should().Be("error");
+        result.IsSuccess.Should().BeFalse("a result initialized as an error should not be successful");
+        result.IsError.Should().BeTrue("a result initialized as an error should indicate an error state");
+        result.Value.Should().Be(value, "the error value passed during initialization should be accessible");
     }
 
 
-    [Fact]
-    public void Result_ShouldBeEqual_WhenInitializedWithSameValue()
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void Result_ShouldBeEqual_WhenInitializedWithSameValue<T>(T value) where T : notnull
     {
         //// Arrange
-        var result1 = new Result<string>("testValue");
-        var result2 = new Result<string>("testValue");
+        var result1 = new Result<T>(value);
+        var result2 = new Result<T>(value);
 
         //// Act && Assert
-        result1.Should().BeEquivalentTo(result2);
+        result1.Should().Be(result2, "results initialized with the same value should be considered equivalent");
     }
 
 
-    [Fact]
-    public void IOneOfValue_ShouldReturnCorrectValue()
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void IOneOfValue_ShouldReturnCorrectValue<T>(T value) where T : notnull
     {
         //// Arrange
-        var testValue = new object();
-        var result = new Result<object>(testValue);
+        var result = new Result<T>(value);
 
         //// Act
         var oneOfValue = ((IOneOf) result).Value;
 
         //// Assert
-        oneOfValue.Should().Be(testValue);
+        oneOfValue.Should().Be(value, "the IOneOf interface should return the same value as the result");
     }
 
 
-    [Fact]
-    public void Index_ShouldAlwaysReturnZero()
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void Index_ShouldAlwaysReturnZero<T>(T value) where T : notnull
     {
         //// Arrange
-        var result = new Result<string>("testValue");
+        var result = new Result<T>(value);
 
         //// Act && Assert
-        result.Index.Should().Be(0);
+        result.Index.Should().Be(0, "the index of a Result should always be 0 as it is not a discriminated union");
     }
 
 
-    [Fact]
-    public void ImplicitOperator_Should_SetIsSuccessToDefault()
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void ImplicitOperator_Should_SetIsSuccessToDefault<T>(T value) where T : notnull
     {
         //// Arrange & Act
-        Result<string> result = "some value";
+        Result<T> result = value;
 
         //// Assert
-        result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be("some value");
+        result.IsSuccess.Should().BeTrue("an implicit conversion from a value should result in a successful Result");
+        result.Value.Should().Be(value, "the implicit conversion should maintain the original value");
     }
 
 
-    [Fact]
-    public void ExplicitOperator_Should_ReturnValue()
+    [Theory]
+    [InlineData("testString", true)]
+    [InlineData("errorString", false)]
+    public void ImplicitOperator_FromTuple_ShouldCorrectlyInitializeResult(string value, bool isSuccess)
+    {
+        //// Arrange & Act
+        Result<string> result = (value, isSuccess);
+
+        //// Assert
+        result.Value.Should().Be(value, "the value should match the input");
+        result.IsSuccess.Should().Be(isSuccess, "the success state should match the input");
+    }
+
+
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void ExplicitOperator_Should_ReturnValue<T>(T value) where T : notnull
     {
         //// Arrange
-        var result = new Result<string>("some value");
+        var result = new Result<T>(value);
 
         //// Act
-        var value = (string) result;
+        var unpacked = (T) result;
 
         //// Assert
-        value.Should().Be("some value");
+        unpacked.Should().Be(value, "an explicit conversion from a Result should return the original value");
     }
 
 
-    [Fact]
-    public void TrueOperator_Should_ReturnTrueIfSuccess()
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void TrueOperator_Should_ReturnTrueIfSuccess<T>(T value) where T : notnull
     {
         //// Arrange
-        var result = new Result<string>("some value");
+        var result = new Result<T>(value);
 
         if (result)
             // Assertion inside condition to ensure it's executed.
-            result.IsSuccess.Should().BeTrue();
+            result.IsSuccess.Should().BeTrue("the true operator should indicate success for a successful Result");
         else
             Assert.Fail("Result should be successful");
     }
 
 
-    [Fact]
-    public void FalseOperator_Should_ReturnTrueIfError()
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void FalseOperator_Should_ReturnTrueIfError<T>(T value) where T : notnull
     {
         //// Arrange
-        var result = new Result<string>("some value", false);
+        var result = new Result<T>(value, false);
 
         if (result)
             Assert.Fail("Result should be an error");
         else
             // Assertion inside condition to ensure it's executed.
-            result.IsError.Should().BeTrue();
+            result.IsError.Should().BeTrue("the false operator should indicate an error for a Result initialized as an error");
     }
 
 
-    [Fact]
-    public void ToString_Should_ReturnCorrectFormatForSuccess()
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void ToString_Should_ReturnCorrectFormatForSuccess<T>(T value) where T : notnull
     {
         //// Arrange
-        var result = new Result<string>("success");
+        var result = new Result<T>(value);
 
         //// Act
         var toString = result.ToString();
 
         //// Assert
         toString.Should()
-                .Contain($"{nameof(Result<string>.IsSuccess)} = True").And
-                .Contain($"{nameof(Result<string>.Value)} = success");
+                .Contain($"{nameof(Result<string>.IsSuccess)} = True", "the ToString output for a successful Result should indicate success")
+                .And.Contain($"{nameof(Result<string>.Value)} = {value}", "the ToString output should include the value for a successful Result");
     }
 
 
-    [Fact]
-    public void ToString_Should_ReturnCorrectFormatForError()
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void ToString_Should_ReturnCorrectFormatForError<T>(T value) where T : notnull
     {
         //// Arrange
-        var result = new Result<string>("error", false);
+        var result = new Result<T>(value, false);
 
         //// Act
         var toString = result.ToString();
 
         //// Assert
         toString.Should()
-                .Contain($"{nameof(Result<string>.IsSuccess)} = False").And
-                .Contain($"{nameof(Result<string>.Value)} = error");
+                .Contain($"{nameof(Result<string>.IsSuccess)} = False", "the ToString output for an error Result should indicate it's not successful")
+                .And.Contain($"{nameof(Result<string>.Value)} = {value}", "the ToString output should include the value even for an error Result");
     }
 
 
@@ -162,23 +186,25 @@ public class ResultTests
         var result2 = new Result<string>("value2");
 
         //// Act
-        var hashCode1 = result1.ToString();
-        var hashCode2 = result2.ToString();
+        var hashCode1 = result1.GetHashCode();
+        var hashCode2 = result2.GetHashCode();
 
         //// Assert
-        hashCode1.Should().NotBe(hashCode2);
+        hashCode1.Should().NotBe(hashCode2, "different Results should have different hash codes");
     }
 
 
-     #pragma warning disable CA1806
     [Fact]
-    public void Result_ShouldThrow_ArgumentNullException_WhenValueIsValue()
+    [SuppressMessage("ReSharper", "ObjectCreationAsStatement")]
+    [SuppressMessage("Performance", "CA1806:Do not ignore method results")]
+    public void Result_ShouldThrow_ArgumentNullException_WhenValueIsNull()
     {
         //// Arrange
-        Action act = () => new Result<string>(null!);
+        var successAction = () => new Result<string>(null!);
+        var errorAction = () => new Result<string>(null!, isSuccess: false);
 
         //// Act && Assert
-        act.Should().ThrowExactly<ArgumentNullException>();
+        successAction.Should().ThrowExactly<ArgumentNullException>("initializing a Result with a null value should throw an ArgumentNullException");
+        errorAction.Should().ThrowExactly<ArgumentNullException>("initializing a Result with a null value should throw an ArgumentNullException");
     }
-     #pragma warning restore CA1806
 }

--- a/tests/UnitTests/StateResults.Tests.Unit/Results3Tests.cs
+++ b/tests/UnitTests/StateResults.Tests.Unit/Results3Tests.cs
@@ -1,0 +1,211 @@
+using BMTLab.OneOf.Reduced;
+
+namespace BMTLab.StateResults.Tests.Units;
+
+// ReSharper disable All
+file class TE0(string? message = default);
+
+file class TE1(string? message = default);
+// ReSharper restore All
+
+
+public class Results3Tests
+{
+    [Theory]
+    [ClassData(typeof(OneTypeClassData))]
+    public void Results_InitializedWithSuccess_ShouldIndicateSuccess<T>(T value) where T : notnull
+    {
+        //// Arrange & Act
+        var result = new Results<T, TE0, TE1>(value);
+
+        //// Assert
+        result.IsSuccess.Should().BeTrue("the result was initialized with a success value");
+        result.IsError.Should().BeFalse("a successful result should not be marked as an error");
+
+        result.Success.Should().NotBeNull("a successful result should have a non-null Success property");
+        result.Error.Should().BeNull("a successful result should not have an Error");
+
+        result.Success.Should()
+              .NotBeNull("the result was initialized with a success value")
+              .And.BeOfType<T>("the result was initialized with a success type")
+              .Subject.Should().Be(value, "the result was initialized with a this value");
+
+        result.Value.Should()
+              .NotBeNull("the result was initialized with a value")
+              .And.BeOfType<T>("the result was initialized with a success type")
+              .And.Be(value, "the result was initialized with a this value");
+
+        result.Index.Should().Be(0, "success values should have an index of 0");
+    }
+
+
+    [Fact]
+    public void Results_InitializedWithError0_ShouldIndicateError()
+    {
+        //// Arrange & Act
+        var error = new TE0("Error");
+        var result = new Results<SomeRecordType, TE0, TE1>(error);
+
+        //// Assert
+        result.IsSuccess.Should().BeFalse("the result was initialized with a error value");
+        result.IsError.Should().BeTrue("a error result should not be marked as a success");
+
+        result.Success.Should().BeNull("a error result should not have an Success");
+        result.Error.Should().NotBeNull("a error result should have a non-null Error property");
+
+        result.Error.Should()
+              .NotBeNull("the result was initialized with a error value")
+              .And.BeOfType<OneOf<TE0, TE1>>("the result was initialized with an error union type")
+              .Subject.Value.Should().Be(error, "the result was initialized with a this value");
+
+        result.Value.Should()
+              .NotBeNull("the result was initialized with a value")
+              .And.BeOfType<TE0>("the result was initialized with a success type")
+              .And.Be(error, "the result was initialized with a this value");
+
+        result.Index.Should().NotBe(0, "error values should not have an index of 0");
+    }
+
+
+    [Fact]
+    public void Match_ShouldExecuteCorrectDelegate_BasedOnState()
+    {
+        //// Arrange
+        Results<string, TE0, TE1> successResult = "Success";
+        Results<string, TE0, TE1> error0Result = new TE0("Error0");
+        Results<string, TE0, TE1> error1Result = new TE1("Error1");
+
+        //// Act & Assert
+        successResult.Match
+        (
+            success =>
+            {
+                success.Should().Be("Success", "the Match function should execute the success delegate when the result is a success");
+
+                return true;
+            },
+            _ =>
+            {
+                Assert.Fail("Error delegate should not be executed for success result.");
+
+                return false;
+            }
+        );
+
+        error0Result.Match
+        (
+            _ =>
+            {
+                Assert.Fail("Success delegate should not be executed for error result.");
+
+                return true;
+            },
+            error =>
+            {
+                error.Value.Should()
+                     .BeOfType<TE0>("the Match function should execute the error delegate with the correct error type")
+                     .And.BeSameAs(error0Result.Value, "the Match function should execute the error delegate with the correct error value");
+
+                return false;
+            }
+        );
+
+        error1Result.Match
+        (
+            _ =>
+            {
+                Assert.Fail("Success delegate should not be executed for error result.");
+
+                return true;
+            },
+            error =>
+            {
+                error.Value.Should()
+                     .BeOfType<TE1>("the Match function should execute the error delegate with the correct error type")
+                     .And.BeSameAs(error1Result.Value, "the Match function should execute the error delegate with the correct error value");
+
+                return false;
+            }
+        );
+    }
+
+
+    [Fact]
+    public void Switch_ShouldExecuteCorrectAction_BasedOnState()
+    {
+        //// Arrange
+        var successResult = new Results<string, TE0, TE1>("Success");
+        var errorResult = new Results<string, TE0, TE1>(new TE0("Error"));
+
+        //// Act & Assert
+        successResult.Switch
+        (
+            success => success.Should().Be("Success", "the Switch function should execute the success action for successful results"),
+            _ => Assert.Fail("Error delegate should not be executed for success result.")
+        );
+
+        errorResult.Switch
+        (
+            _ => Assert.Fail("Success delegate should not be executed for error result."),
+            error =>
+                error.Value.Should()
+                     .BeOfType<TE0>("the Switch function should execute the error delegate with the correct error type")
+                     .And.BeSameAs(errorResult.Value, "the Switch function should execute the error delegate with the correct error value")
+        );
+    }
+
+
+    [Fact]
+    public void ExplicitOperator_ShouldCastCorrectly_BasedOnState()
+    {
+        //// Arrange
+        Results<string, TE0, TE1> successResult = "Success";
+
+        //// Act
+        var successFunction = () => (string) successResult;
+
+        //// Assert
+        successFunction.Should().NotThrow("explicit casting to the success type should be valid for success results");
+    }
+
+
+    [Fact]
+    public void GetHashCode_ShouldBeConsistent_WhenSuccessType()
+    {
+        //// Arrange
+        var result1 = new Results<string, TE0, TE1>("Value");
+        var result2 = new Results<string, TE0, TE1>("Value");
+        var result3 = new Results<string, TE0, TE1>("OtherValue");
+
+        //// Act & Assert
+        result1.GetHashCode().Should().Be(result2.GetHashCode(), "results initialized with the same value should have the same hash code");
+        result1.GetHashCode().Should().NotBe(result3.GetHashCode(), "results initialized with the different values should have the different hash code");
+    }
+
+
+    [Fact]
+    public void GetHashCode_ShouldBeConsistent_WhenErrorType()
+    {
+        //// Arrange
+        var errorResult1 = new Results<string, TE0, TE1>(new TE0("Value"));
+        var errorResult2 = new Results<string, TE0, TE1>(new TE0("OtherValue"));
+
+        //// Act & Assert
+        errorResult1.GetHashCode().Should().NotBe(errorResult2.GetHashCode(), "error results initialized with the same value should have the same hash code");
+    }
+
+
+    [Fact]
+    [SuppressMessage("ReSharper", "ObjectCreationAsStatement")]
+    [SuppressMessage("Performance", "CA1806:Do not ignore method results")]
+    public void Results_ShouldThrow_ArgumentNullException_WhenValueIsNull()
+    {
+        //// Arrange
+        var successAction = () => new Results<string, TE0, TE1>((string) null!);
+        var errorAction = () => new Results<string, TE0, TE1>((OneOf<TE0, TE1>) null!);
+
+        //// Act & Assert
+        successAction.Should().ThrowExactly<ArgumentNullException>("initializing a Results with a null success value is invalid");
+        errorAction.Should().ThrowExactly<ArgumentNullException>("initializing a Results with a null error is invalid");
+    }
+}


### PR DESCRIPTION
This PR contains some code improvements and small bug fixes that do not affect the API. 
However, there is a **critical change** in this PR related to `Index` property of `Results` structures.

Previously, the property returned `0` if the structure was initialized with a "success" type and `1` if it was initialized with any "error" type

```csharp
    public int Index => _index; // internal _index is 0 or 1
```

then this property now returns the sequence number of the type the structure was initialized with, which makes more sense. 

```csharp
    public int Index => _index switch
    {
        0 when Success is not null => 0,
        1 when Error is not null   => Error.Index + 1 // retrieve OneOf's Index 
    };
```

`0` still means "successful" type. And now it looks like an implementation of _OneOf.Reduced_.